### PR TITLE
Fixes issue #2 in tpfplotter

### DIFF
--- a/tpfplotter.py
+++ b/tpfplotter.py
@@ -148,8 +148,12 @@ def get_gaia_data(ra, dec):
         raise no_targets_found_message
     elif len(result) == 0:
         raise too_few_found_message
-    
-    return result[0]['Source'], result[0]['Gmag']
+    if len(result)>1:
+        dist = np.sqrt((result['RA_ICRS']-ra)**2 + (result['DE_ICRS']-dec)**2)
+        idx = np.where(dist == np.min(dist))[0][0]
+        return result[idx]['Source'], result[idx]['Gmag']
+    else:
+        return result[0]['Source'], result[0]['Gmag']
  	
 def get_coord(tic):
 	"""

--- a/tpfplotter_py3.py
+++ b/tpfplotter_py3.py
@@ -147,8 +147,12 @@ def get_gaia_data(ra, dec):
         raise no_targets_found_message
     elif len(result) == 0:
         raise too_few_found_message
-
-    return result[0]['Source'], result[0]['Gmag']
+    if len(result)>1:
+        dist = np.sqrt((result['RA_ICRS']-ra)**2 + (result['DE_ICRS']-dec)**2)
+        idx = np.where(dist == np.min(dist))[0][0]
+        return result[idx]['Source'], result[idx]['Gmag']
+    else:   
+        return result[0]['Source'], result[0]['Gmag']
 
 def get_coord(tic):
 	"""


### PR DESCRIPTION
Hola Jorge!

 Very straightforward [fix to issue number 2 that I opened on tpfplotter](https://github.com/jlillo/tpfplotter/issues/2). If the `result` table has more than 1 element, then it calculates the distance between input coordinates and the RA and DEC in the results, and returns the one with the minimum distance (i.e., the closest object to the input coordinates).

 Best,
Néstor